### PR TITLE
plugin should not install javascript into platforms other than ios

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -9,12 +9,12 @@
         <engine name="cordova" version=">=3.0.0" />
     </engines>
 
-    <js-module src="www/applicationPreferences.js" name="applicationPreferences">
-        <clobbers target="applicationPreferences" />
-    </js-module>
-
     <!-- ios -->
     <platform name="ios">
+        <js-module src="www/applicationPreferences.js" name="applicationPreferences">
+            <clobbers target="applicationPreferences" />
+        </js-module>
+
         <config-file target="config.xml" parent="/*">
             <feature name="applicationPreferences">
                 <param name="ios-package" value="applicationPreferences" />


### PR DESCRIPTION
Currently the plugin installs the javascript part of the plugin to all platforms, while there is only an ios implementation.
